### PR TITLE
add functions to generate pdf, png, and svg

### DIFF
--- a/examples/basic-application/basic_application.cpp
+++ b/examples/basic-application/basic_application.cpp
@@ -24,7 +24,6 @@
 
 #include "ezgl/application.hpp"
 #include "ezgl/graphics.hpp"
-#include "ezgl/canvas.hpp"
 
 // Callback functions for event handling
 void act_on_mouse_press(ezgl::application *application, GdkEventButton *event, double x, double y);

--- a/examples/basic-application/basic_application.cpp
+++ b/examples/basic-application/basic_application.cpp
@@ -541,7 +541,8 @@ void test_button(GtkWidget *widget, ezgl::application *application)
   
   // Redraw the main canvas
   application->refresh_drawing();
-
+  std::cout << "see me!" << std::endl;
+//  application->get_canvas(application->get_main_canvas_id())->print_pdf("test_test");
   // Draw a temporary rectangle border
   ezgl::renderer g = application->get_renderer();
   g.set_line_width(1);

--- a/examples/basic-application/basic_application.cpp
+++ b/examples/basic-application/basic_application.cpp
@@ -537,6 +537,8 @@ void test_button(GtkWidget *widget, ezgl::application *application)
 {
   // Update the status bar message
   application->update_message("Test Button Pressed");
+  
+    create_pdf_surface(widget);
 
   // Redraw the main canvas
   application->refresh_drawing();

--- a/examples/basic-application/basic_application.cpp
+++ b/examples/basic-application/basic_application.cpp
@@ -24,6 +24,7 @@
 
 #include "ezgl/application.hpp"
 #include "ezgl/graphics.hpp"
+#include "ezgl/canvas.hpp"
 
 #include <iostream>
 
@@ -538,8 +539,6 @@ void test_button(GtkWidget *widget, ezgl::application *application)
   // Update the status bar message
   application->update_message("Test Button Pressed");
   
-    create_pdf_surface(widget);
-
   // Redraw the main canvas
   application->refresh_drawing();
 

--- a/examples/basic-application/basic_application.cpp
+++ b/examples/basic-application/basic_application.cpp
@@ -26,8 +26,6 @@
 #include "ezgl/graphics.hpp"
 #include "ezgl/canvas.hpp"
 
-#include <iostream>
-
 // Callback functions for event handling
 void act_on_mouse_press(ezgl::application *application, GdkEventButton *event, double x, double y);
 void act_on_mouse_move(ezgl::application *application, GdkEventButton *event, double x, double y);
@@ -541,8 +539,7 @@ void test_button(GtkWidget *widget, ezgl::application *application)
   
   // Redraw the main canvas
   application->refresh_drawing();
-  std::cout << "see me!" << std::endl;
-//  application->get_canvas(application->get_main_canvas_id())->print_pdf("test_test");
+
   // Draw a temporary rectangle border
   ezgl::renderer g = application->get_renderer();
   g.set_line_width(1);

--- a/include/ezgl/canvas.hpp
+++ b/include/ezgl/canvas.hpp
@@ -50,7 +50,9 @@ class renderer;
  *                      generating a temporary file.
  * @return              a pointer to the newly created surface. The caller owns 
  *                      the surface and should call cairo_surface_destroy() when 
- *                      done with it.
+ *                      done with it. 
+ *                      Always returns a valid pointer, but it will return a pointer 
+ *                      to a NULL surface if an error such as out of memory occurs. 
  * 
  * sample code: http://zetcode.com/gfx/cairo/cairobackends/
  */
@@ -135,8 +137,19 @@ public:
    */
   renderer create_temporary_renderer();
   
-  void print_pdf(const char *file_name);
-
+  /**
+   * print_pdf, print_svg, and print_png generate a PDF, SVG, or PNG output file showing 
+   * all the graphical content of the current canvas. 
+   * 
+   * @param file_name   name of the output file
+   * @return            returns true if the function has successfully generated the output file, otherwise
+   *                    failed due to errors such as out of memory occurs. 
+   */
+  bool print_pdf(const char *file_name);
+  bool print_svg(const char *file_name);
+  bool print_png(const char *file_name);
+  
+  
 protected:
   // Only the ezgl::application can create and initialize a canvas object.
   friend class application;

--- a/include/ezgl/canvas.hpp
+++ b/include/ezgl/canvas.hpp
@@ -134,6 +134,8 @@ public:
    * The created renderer should be used only in the same callback in which it was created
    */
   renderer create_temporary_renderer();
+  
+  void print_pdf(const char *file_name);
 
 protected:
   // Only the ezgl::application can create and initialize a canvas object.

--- a/include/ezgl/canvas.hpp
+++ b/include/ezgl/canvas.hpp
@@ -38,37 +38,6 @@ namespace ezgl {
 class renderer;
 
 /**
- * create_and_generate_pdf and create_and_generate_svg both create a surface and generate an file output.
- * 
- * @param widget        a widget which specifies the width and the height of the 
- *                      surface generated. Can use any widget — button, window, etc. 
- *                      Should be using the MainCanvas (GtkDrawingArea) to save the
- *                      graphical content shown in the main canvas.
- * @param file_name:    a filename for the PDF output (must be writable), NULL may 
- *                      be used to specify no output. This will generate a PDF/SVG 
- *                      surface that may be queried and used as a source, without 
- *                      generating a temporary file.
- * @return              a pointer to the newly created surface. The caller owns 
- *                      the surface and should call cairo_surface_destroy() when 
- *                      done with it. 
- *                      Always returns a valid pointer, but it will return a pointer 
- *                      to a NULL surface if an error such as out of memory occurs. 
- * 
- * sample code: http://zetcode.com/gfx/cairo/cairobackends/
- */
-cairo_surface_t *create_and_generate_pdf(GtkWidget *widget, const char *file_name);
-cairo_surface_t *create_and_generate_svg(GtkWidget *widget, const char *file_name);
-
-/**
- * create_png and generate_png work the same way as create_and_generate_pdf and create_and_generate_svg,
- * while the process is broken into two separate functions due to the corresponding cairo functions. 
- * Please refer to the comments for create_and_generate_pdf/create_and_generate_svg above.
- * Pass the return value of create_png into generate_png to generate an output png file.
- */
-cairo_surface_t *create_png(GtkWidget *widget);
-cairo_public cairo_status_t generate_png(cairo_surface_t *p_surface, const char *file_name);
-
-/**
  * The signature of a function that draws to an ezgl::canvas.
  */
 using draw_canvas_fn = void (*)(renderer &);

--- a/include/ezgl/canvas.hpp
+++ b/include/ezgl/canvas.hpp
@@ -36,9 +36,35 @@ namespace ezgl {
 /**** Functions in this class are for ezgl internal use; application code doesn't need to call them ****/
 
 class renderer;
-cairo_surface_t *create_pdf_surface(GtkWidget *widget);
-cairo_surface_t *create_svg_surface(GtkWidget *widget);
-cairo_surface_t *create_png_surface(GtkWidget *widget);
+
+/**
+ * create_and_generate_pdf and create_and_generate_svg both create a surface and generate an file output.
+ * 
+ * @param widget        a widget which specifies the width and the height of the 
+ *                      surface generated. Can use any widget — button, window, etc. 
+ *                      Should be using the MainCanvas (GtkDrawingArea) to save the
+ *                      graphical content shown in the main canvas.
+ * @param file_name:    a filename for the PDF output (must be writable), NULL may 
+ *                      be used to specify no output. This will generate a PDF/SVG 
+ *                      surface that may be queried and used as a source, without 
+ *                      generating a temporary file.
+ * @return              a pointer to the newly created surface. The caller owns 
+ *                      the surface and should call cairo_surface_destroy() when 
+ *                      done with it.
+ * 
+ * sample code: http://zetcode.com/gfx/cairo/cairobackends/
+ */
+cairo_surface_t *create_and_generate_pdf(GtkWidget *widget, const char *file_name);
+cairo_surface_t *create_and_generate_svg(GtkWidget *widget, const char *file_name);
+
+/**
+ * create_png and generate_png work the same way as create_and_generate_pdf and create_and_generate_svg,
+ * while the process is broken into two separate functions due to the corresponding cairo functions. 
+ * Please refer to the comments for create_and_generate_pdf/create_and_generate_svg above.
+ * Pass the return value of create_png into generate_png to generate an output png file.
+ */
+cairo_surface_t *create_png(GtkWidget *widget);
+cairo_public cairo_status_t generate_png(cairo_surface_t *p_surface, const char *file_name);
 
 /**
  * The signature of a function that draws to an ezgl::canvas.

--- a/include/ezgl/canvas.hpp
+++ b/include/ezgl/canvas.hpp
@@ -25,6 +25,8 @@
 #include "ezgl/color.hpp"
 
 #include <cairo.h>
+#include <cairo-pdf.h>
+#include <cairo-svg.h>
 #include <gtk/gtk.h>
 
 #include <string>

--- a/include/ezgl/canvas.hpp
+++ b/include/ezgl/canvas.hpp
@@ -36,6 +36,9 @@ namespace ezgl {
 /**** Functions in this class are for ezgl internal use; application code doesn't need to call them ****/
 
 class renderer;
+cairo_surface_t *create_pdf_surface(GtkWidget *widget);
+cairo_surface_t *create_svg_surface(GtkWidget *widget);
+cairo_surface_t *create_png_surface(GtkWidget *widget);
 
 /**
  * The signature of a function that draws to an ezgl::canvas.

--- a/include/ezgl/graphics.hpp
+++ b/include/ezgl/graphics.hpp
@@ -25,8 +25,6 @@
 #include "ezgl/camera.hpp"
 
 #include <cairo.h>
-#include <cairo-pdf.h>
-#include <cairo-svg.h>
 #include <gdk/gdk.h>
 
 #ifdef CAIRO_HAS_XLIB_SURFACE

--- a/include/ezgl/graphics.hpp
+++ b/include/ezgl/graphics.hpp
@@ -25,6 +25,8 @@
 #include "ezgl/camera.hpp"
 
 #include <cairo.h>
+#include <cairo-pdf.h>
+#include <cairo-svg.h>
 #include <gdk/gdk.h>
 
 #ifdef CAIRO_HAS_XLIB_SURFACE

--- a/src/canvas.cpp
+++ b/src/canvas.cpp
@@ -54,15 +54,6 @@ static cairo_surface_t *create_pdf_surface(GtkWidget *widget)
 
 }
 
-static cairo_surface_t *create_png_surface(GtkWidget *widget)
-{
-  int const width = gtk_widget_get_allocated_width(widget);
-  int const height = gtk_widget_get_allocated_height(widget);
-
-  return cairo_image_surface_create(CAIRO_FORMAT_ARGB32, width, height);
-
-}
-
 static cairo_surface_t *create_svg_surface(GtkWidget *widget)
 {
     std::string file_name = "svg_output";
@@ -70,6 +61,15 @@ static cairo_surface_t *create_svg_surface(GtkWidget *widget)
   int const height = gtk_widget_get_allocated_height(widget);
 
   return cairo_svg_surface_create(file_name.c_str(), width, height);
+
+}
+
+static cairo_surface_t *create_png_surface(GtkWidget *widget)
+{
+  int const width = gtk_widget_get_allocated_width(widget);
+  int const height = gtk_widget_get_allocated_height(widget);
+
+  return cairo_image_surface_create(CAIRO_FORMAT_ARGB32, width, height);
 
 }
 
@@ -84,22 +84,6 @@ static cairo_t *create_context(cairo_surface_t *p_surface)
 
   return context;
 }
-
-//static cairo_status_t *create_png_context(cairo_surface_t *p_surface)
-//{
-//    std::string file_name = "png_output";
-//  cairo_status_t *context = cairo_surface_write_to_png(p_surface, file_name.c_str());
-//
-//  return context;
-//}
-//
-//static cairo_status_t *create_pdf_context(cairo_surface_t *p_surface)
-//{
-//    std::string file_name = "png_output";
-//  cairo_status_t *context = cairo_surface_write_to_png(p_surface, file_name.c_str());
-//
-//  return context;
-//}
 
 gboolean canvas::configure_event(GtkWidget *widget, GdkEventConfigure *, gpointer data)
 {

--- a/src/canvas.cpp
+++ b/src/canvas.cpp
@@ -28,242 +28,250 @@
 
 namespace ezgl {
 
-    static cairo_surface_t *create_surface(GtkWidget *widget)
-    {
-      GdkWindow *parent_window = gtk_widget_get_window(widget);
-      int const width = gtk_widget_get_allocated_width(widget);
-      int const height = gtk_widget_get_allocated_height(widget);
+static cairo_surface_t *create_surface(GtkWidget *widget)
+{
+  GdkWindow *parent_window = gtk_widget_get_window(widget);
+  int const width = gtk_widget_get_allocated_width(widget);
+  int const height = gtk_widget_get_allocated_height(widget);
 
-      // Cairo image surfaces are more efficient than normal Cairo surfaces
-      // However, you cannot use X11 functions to draw on image surfaces
-    #ifdef EZGL_USE_X11
-      return gdk_window_create_similar_surface(parent_window, CAIRO_CONTENT_COLOR_ALPHA, width, height);
-    #else
-      return gdk_window_create_similar_image_surface(
-          parent_window, CAIRO_FORMAT_ARGB32, width, height, 0);
-    #endif
-    }
-
-    static cairo_t *create_context(cairo_surface_t *p_surface)
-    {
-      cairo_t *context = cairo_create(p_surface);
-
-      // Set the antialiasing mode of the rasterizer used for drawing shapes
-      // Set to CAIRO_ANTIALIAS_NONE for maximum speed
-      // See https://www.cairographics.org/manual/cairo-cairo-t.html#cairo-antialias-t
-      cairo_set_antialias(context, CAIRO_ANTIALIAS_NONE);
-
-      return context;
-    }
-
-    bool canvas::print_pdf(const char *file_name)
-    {
-        cairo_surface_t *surface;
-        cairo_t *context;
-        
-        // create pdf surface based on canvas size
-        int const width = gtk_widget_get_allocated_width(m_drawing_area);
-        int const height = gtk_widget_get_allocated_height(m_drawing_area);
-        surface = cairo_pdf_surface_create(file_name, width, height);
-        
-        if(surface == NULL) return false; // failed to create due to errors such as out of memory
-        context = create_context(surface);
-
-        // draw on the newly created pdf surface & context
-        cairo_set_source_rgb(context, m_background_color.red / 255.0,
-                                m_background_color.green / 255.0, m_background_color.blue / 255.0);
-        cairo_paint(context);
-
-        using namespace std::placeholders;
-        renderer g(context, std::bind(&camera::world_to_screen, m_camera, _1), &m_camera, surface);
-        m_draw_callback(g);
-
-        // free surface & context
-        cairo_surface_destroy(surface);
-        cairo_destroy(context);
-        
-        return true;
-    }
-    
-    bool canvas::print_svg(const char *file_name)
-    {
-        cairo_surface_t *surface;
-        cairo_t *context;
-        
-        // create svg surface based on canvas size
-        int const width = gtk_widget_get_allocated_width(m_drawing_area);
-        int const height = gtk_widget_get_allocated_height(m_drawing_area);
-        surface = cairo_svg_surface_create(file_name, width, height);
-        
-        if(surface == NULL) return false; // failed to create due to errors such as out of memory
-        context = create_context(surface);
-
-        // draw on the newly created svg surface & context
-        cairo_set_source_rgb(context, m_background_color.red / 255.0,
-                                m_background_color.green / 255.0, m_background_color.blue / 255.0);
-        cairo_paint(context);
-
-        using namespace std::placeholders;
-        renderer g(context, std::bind(&camera::world_to_screen, m_camera, _1), &m_camera, surface);
-        m_draw_callback(g);
-
-        // free surface & context
-        cairo_surface_destroy(surface);
-        cairo_destroy(context);
-        
-        return true;
-    }
-    
-    bool canvas::print_png(const char *file_name)
-    {
-        cairo_surface_t *surface;
-        cairo_t *context;
-        
-        // create png surface based on canvas size
-        int const width = gtk_widget_get_allocated_width(m_drawing_area);
-        int const height = gtk_widget_get_allocated_height(m_drawing_area);
-        surface = cairo_image_surface_create(CAIRO_FORMAT_ARGB32, width, height);
-        
-        if(surface == NULL) return false; // failed to create due to errors such as out of memory
-        context = create_context(surface);
-        
-        // draw on the newly created png surface & context
-        cairo_set_source_rgb(context, m_background_color.red / 255.0,
-                                m_background_color.green / 255.0, m_background_color.blue / 255.0);
-        cairo_paint(context);
-        using namespace std::placeholders;
-        renderer g(context, std::bind(&camera::world_to_screen, m_camera, _1), &m_camera, surface);
-        m_draw_callback(g);
-        
-        // create png output file
-        cairo_surface_write_to_png(surface, file_name);
-        
-        // free surface & context
-        cairo_surface_destroy(surface);
-        cairo_destroy(context);
-        
-        return true;
-    }
-
-    gboolean canvas::configure_event(GtkWidget *widget, GdkEventConfigure *, gpointer data)
-    {
-      // User data should have been set during the signal connection.
-      g_return_val_if_fail(data != nullptr, FALSE);
-
-      auto ezgl_canvas = static_cast<canvas *>(data);
-      auto &p_surface = ezgl_canvas->m_surface;
-      auto &p_context = ezgl_canvas->m_context;
-
-      if(p_surface != nullptr) {
-        cairo_surface_destroy(p_surface);
-      }
-
-      if(p_context != nullptr) {
-        cairo_destroy(p_context);
-      }
-
-      // Something has changed, recreate the surface.
-      p_surface = create_surface(widget);
-
-      // Recreate the context
-      p_context = create_context(p_surface);
-
-      // The camera needs to be updated before we start drawing again.
-      ezgl_canvas->m_camera.update_widget(ezgl_canvas->width(), ezgl_canvas->height());
-
-      // Draw to the newly created surface.
-      ezgl_canvas->redraw();
-
-      g_info("canvas::configure_event has been handled.");
-      return TRUE; // the configure event was handled
-    }
-
-    gboolean canvas::draw_surface(GtkWidget *, cairo_t *context, gpointer data)
-    {
-      // Assume context and data are non-null.
-      auto &p_surface = static_cast<canvas *>(data)->m_surface;
-
-      // Assume surface is non-null.
-      cairo_set_source_surface(context, p_surface, 0, 0);
-      cairo_paint(context);
-
-      return FALSE;
-    }
-
-    canvas::canvas(std::string canvas_id, draw_canvas_fn draw_callback, rectangle coordinate_system, color background_color)
-        : m_canvas_id(std::move(canvas_id)), m_draw_callback(draw_callback), m_camera(coordinate_system),
-          m_background_color(background_color)
-    {
-    }
-
-    canvas::~canvas()
-    {
-      if(m_surface != nullptr) {
-        cairo_surface_destroy(m_surface);
-      }
-
-      if(m_context != nullptr) {
-        cairo_destroy(m_context);
-      }
-    }
-
-    int canvas::width() const
-    {
-      return gtk_widget_get_allocated_width(m_drawing_area);
-    }
-
-    int canvas::height() const
-    {
-      return gtk_widget_get_allocated_height(m_drawing_area);
-    }
-
-    void canvas::initialize(GtkWidget *drawing_area)
-    {
-      g_return_if_fail(drawing_area != nullptr);
-
-      m_drawing_area = drawing_area;
-      m_surface = create_surface(m_drawing_area);
-      m_context = create_context(m_surface);
-      m_camera.update_widget(width(), height());
-
-      // Draw to the newly created surface for the first time.
-      redraw();
-
-      // Connect to configure events in case our widget changes shape.
-      g_signal_connect(m_drawing_area, "configure-event", G_CALLBACK(configure_event), this);
-      // Connect to draw events so that we draw our surface to the drawing area.
-      g_signal_connect(m_drawing_area, "draw", G_CALLBACK(draw_surface), this);
-
-      // GtkDrawingArea objects need specific events enabled explicitly.
-      gtk_widget_add_events(GTK_WIDGET(m_drawing_area), GDK_BUTTON_PRESS_MASK);
-      gtk_widget_add_events(GTK_WIDGET(m_drawing_area), GDK_BUTTON_RELEASE_MASK);
-      gtk_widget_add_events(GTK_WIDGET(m_drawing_area), GDK_POINTER_MOTION_MASK);
-      gtk_widget_add_events(GTK_WIDGET(m_drawing_area), GDK_SCROLL_MASK);
-
-      g_info("canvas::initialize successful.");
-    }
-
-    void canvas::redraw()
-    {
-      // Clear the screen and set the background color
-      cairo_set_source_rgb(m_context, m_background_color.red / 255.0,
-                           m_background_color.green / 255.0, m_background_color.blue / 255.0);
-      cairo_paint(m_context);
-
-      using namespace std::placeholders;
-      renderer g(m_context, std::bind(&camera::world_to_screen, m_camera, _1), &m_camera, m_surface);
-      m_draw_callback(g);
-
-      gtk_widget_queue_draw(m_drawing_area);
-
-      g_info("The canvas will be redrawn.");
-    }
-
-    renderer canvas::create_temporary_renderer()
-    {
-      using namespace std::placeholders;
-      renderer g(m_context, std::bind(&camera::world_to_screen, m_camera, _1), &m_camera, m_surface);
-
-      return g;
-    }
+  // Cairo image surfaces are more efficient than normal Cairo surfaces
+  // However, you cannot use X11 functions to draw on image surfaces
+#ifdef EZGL_USE_X11
+  return gdk_window_create_similar_surface(parent_window, CAIRO_CONTENT_COLOR_ALPHA, width, height);
+#else
+  return gdk_window_create_similar_image_surface(
+      parent_window, CAIRO_FORMAT_ARGB32, width, height, 0);
+#endif
 }
+
+static cairo_t *create_context(cairo_surface_t *p_surface)
+{
+  cairo_t *context = cairo_create(p_surface);
+
+  // Set the antialiasing mode of the rasterizer used for drawing shapes
+  // Set to CAIRO_ANTIALIAS_NONE for maximum speed
+  // See https://www.cairographics.org/manual/cairo-cairo-t.html#cairo-antialias-t
+  cairo_set_antialias(context, CAIRO_ANTIALIAS_NONE);
+
+  return context;
+}
+
+bool canvas::print_pdf(const char *file_name)
+{
+  cairo_surface_t *surface;
+  cairo_t *context;
+
+  // create pdf surface based on canvas size
+  int const width = gtk_widget_get_allocated_width(m_drawing_area);
+  int const height = gtk_widget_get_allocated_height(m_drawing_area);
+  surface = cairo_pdf_surface_create(file_name, width, height);
+
+  if(surface == NULL)
+    return false; // failed to create due to errors such as out of memory
+  context = create_context(surface);
+
+  // draw on the newly created pdf surface & context
+  cairo_set_source_rgb(context, m_background_color.red / 255.0, m_background_color.green / 255.0,
+      m_background_color.blue / 255.0);
+  cairo_paint(context);
+
+  using namespace std::placeholders;
+  renderer g(context, std::bind(&camera::world_to_screen, m_camera, _1), &m_camera, surface);
+  m_draw_callback(g);
+
+  // free surface & context
+  cairo_surface_destroy(surface);
+  cairo_destroy(context);
+
+  return true;
+}
+
+bool canvas::print_svg(const char *file_name)
+{
+  cairo_surface_t *surface;
+  cairo_t *context;
+
+  // create svg surface based on canvas size
+  int const width = gtk_widget_get_allocated_width(m_drawing_area);
+  int const height = gtk_widget_get_allocated_height(m_drawing_area);
+  surface = cairo_svg_surface_create(file_name, width, height);
+
+  if(surface == NULL)
+    return false; // failed to create due to errors such as out of memory
+  context = create_context(surface);
+
+  // draw on the newly created svg surface & context
+  cairo_set_source_rgb(context, m_background_color.red / 255.0, m_background_color.green / 255.0,
+      m_background_color.blue / 255.0);
+  cairo_paint(context);
+
+  using namespace std::placeholders;
+  renderer g(context, std::bind(&camera::world_to_screen, m_camera, _1), &m_camera, surface);
+  m_draw_callback(g);
+
+  // free surface & context
+  cairo_surface_destroy(surface);
+  cairo_destroy(context);
+
+  return true;
+}
+
+bool canvas::print_png(const char *file_name)
+{
+  cairo_surface_t *surface;
+  cairo_t *context;
+
+  // create png surface based on canvas size
+  int const width = gtk_widget_get_allocated_width(m_drawing_area);
+  int const height = gtk_widget_get_allocated_height(m_drawing_area);
+  surface = cairo_image_surface_create(CAIRO_FORMAT_ARGB32, width, height);
+
+  if(surface == NULL)
+    return false; // failed to create due to errors such as out of memory
+  context = create_context(surface);
+
+  // draw on the newly created png surface & context
+  cairo_set_source_rgb(context, m_background_color.red / 255.0, m_background_color.green / 255.0,
+      m_background_color.blue / 255.0);
+  cairo_paint(context);
+  using namespace std::placeholders;
+  renderer g(context, std::bind(&camera::world_to_screen, m_camera, _1), &m_camera, surface);
+  m_draw_callback(g);
+
+  // create png output file
+  cairo_surface_write_to_png(surface, file_name);
+
+  // free surface & context
+  cairo_surface_destroy(surface);
+  cairo_destroy(context);
+
+  return true;
+}
+
+gboolean canvas::configure_event(GtkWidget *widget, GdkEventConfigure *, gpointer data)
+{
+  // User data should have been set during the signal connection.
+  g_return_val_if_fail(data != nullptr, FALSE);
+
+  auto ezgl_canvas = static_cast<canvas *>(data);
+  auto &p_surface = ezgl_canvas->m_surface;
+  auto &p_context = ezgl_canvas->m_context;
+
+  if(p_surface != nullptr) {
+    cairo_surface_destroy(p_surface);
+  }
+
+  if(p_context != nullptr) {
+    cairo_destroy(p_context);
+  }
+
+  // Something has changed, recreate the surface.
+  p_surface = create_surface(widget);
+
+  // Recreate the context
+  p_context = create_context(p_surface);
+
+  // The camera needs to be updated before we start drawing again.
+  ezgl_canvas->m_camera.update_widget(ezgl_canvas->width(), ezgl_canvas->height());
+
+  // Draw to the newly created surface.
+  ezgl_canvas->redraw();
+
+  g_info("canvas::configure_event has been handled.");
+  return TRUE; // the configure event was handled
+}
+
+gboolean canvas::draw_surface(GtkWidget *, cairo_t *context, gpointer data)
+{
+  // Assume context and data are non-null.
+  auto &p_surface = static_cast<canvas *>(data)->m_surface;
+
+  // Assume surface is non-null.
+  cairo_set_source_surface(context, p_surface, 0, 0);
+  cairo_paint(context);
+
+  return FALSE;
+}
+
+canvas::canvas(std::string canvas_id,
+    draw_canvas_fn draw_callback,
+    rectangle coordinate_system,
+    color background_color)
+    : m_canvas_id(std::move(canvas_id))
+    , m_draw_callback(draw_callback)
+    , m_camera(coordinate_system)
+    , m_background_color(background_color)
+{
+}
+
+canvas::~canvas()
+{
+  if(m_surface != nullptr) {
+    cairo_surface_destroy(m_surface);
+  }
+
+  if(m_context != nullptr) {
+    cairo_destroy(m_context);
+  }
+}
+
+int canvas::width() const
+{
+  return gtk_widget_get_allocated_width(m_drawing_area);
+}
+
+int canvas::height() const
+{
+  return gtk_widget_get_allocated_height(m_drawing_area);
+}
+
+void canvas::initialize(GtkWidget *drawing_area)
+{
+  g_return_if_fail(drawing_area != nullptr);
+
+  m_drawing_area = drawing_area;
+  m_surface = create_surface(m_drawing_area);
+  m_context = create_context(m_surface);
+  m_camera.update_widget(width(), height());
+
+  // Draw to the newly created surface for the first time.
+  redraw();
+
+  // Connect to configure events in case our widget changes shape.
+  g_signal_connect(m_drawing_area, "configure-event", G_CALLBACK(configure_event), this);
+  // Connect to draw events so that we draw our surface to the drawing area.
+  g_signal_connect(m_drawing_area, "draw", G_CALLBACK(draw_surface), this);
+
+  // GtkDrawingArea objects need specific events enabled explicitly.
+  gtk_widget_add_events(GTK_WIDGET(m_drawing_area), GDK_BUTTON_PRESS_MASK);
+  gtk_widget_add_events(GTK_WIDGET(m_drawing_area), GDK_BUTTON_RELEASE_MASK);
+  gtk_widget_add_events(GTK_WIDGET(m_drawing_area), GDK_POINTER_MOTION_MASK);
+  gtk_widget_add_events(GTK_WIDGET(m_drawing_area), GDK_SCROLL_MASK);
+
+  g_info("canvas::initialize successful.");
+}
+
+void canvas::redraw()
+{
+  // Clear the screen and set the background color
+  cairo_set_source_rgb(m_context, m_background_color.red / 255.0, m_background_color.green / 255.0,
+      m_background_color.blue / 255.0);
+  cairo_paint(m_context);
+
+  using namespace std::placeholders;
+  renderer g(m_context, std::bind(&camera::world_to_screen, m_camera, _1), &m_camera, m_surface);
+  m_draw_callback(g);
+
+  gtk_widget_queue_draw(m_drawing_area);
+
+  g_info("The canvas will be redrawn.");
+}
+
+renderer canvas::create_temporary_renderer()
+{
+  using namespace std::placeholders;
+  renderer g(m_context, std::bind(&camera::world_to_screen, m_camera, _1), &m_camera, m_surface);
+
+  return g;
+}
+} // namespace ezgl

--- a/src/canvas.cpp
+++ b/src/canvas.cpp
@@ -44,6 +44,35 @@ static cairo_surface_t *create_surface(GtkWidget *widget)
 #endif
 }
 
+static cairo_surface_t *create_pdf_surface(GtkWidget *widget)
+{
+    std::string file_name = "pdf_output";
+  int const width = gtk_widget_get_allocated_width(widget);
+  int const height = gtk_widget_get_allocated_height(widget);
+
+  return cairo_pdf_surface_create(file_name.c_str(), width, height);
+
+}
+
+static cairo_surface_t *create_png_surface(GtkWidget *widget)
+{
+  int const width = gtk_widget_get_allocated_width(widget);
+  int const height = gtk_widget_get_allocated_height(widget);
+
+  return cairo_image_surface_create(CAIRO_FORMAT_ARGB32, width, height);
+
+}
+
+static cairo_surface_t *create_svg_surface(GtkWidget *widget)
+{
+    std::string file_name = "svg_output";
+  int const width = gtk_widget_get_allocated_width(widget);
+  int const height = gtk_widget_get_allocated_height(widget);
+
+  return cairo_svg_surface_create(file_name.c_str(), width, height);
+
+}
+
 static cairo_t *create_context(cairo_surface_t *p_surface)
 {
   cairo_t *context = cairo_create(p_surface);
@@ -55,6 +84,22 @@ static cairo_t *create_context(cairo_surface_t *p_surface)
 
   return context;
 }
+
+//static cairo_status_t *create_png_context(cairo_surface_t *p_surface)
+//{
+//    std::string file_name = "png_output";
+//  cairo_status_t *context = cairo_surface_write_to_png(p_surface, file_name.c_str());
+//
+//  return context;
+//}
+//
+//static cairo_status_t *create_pdf_context(cairo_surface_t *p_surface)
+//{
+//    std::string file_name = "png_output";
+//  cairo_status_t *context = cairo_surface_write_to_png(p_surface, file_name.c_str());
+//
+//  return context;
+//}
 
 gboolean canvas::configure_event(GtkWidget *widget, GdkEventConfigure *, gpointer data)
 {

--- a/src/canvas.cpp
+++ b/src/canvas.cpp
@@ -45,33 +45,33 @@ static cairo_surface_t *create_surface(GtkWidget *widget)
 #endif
 }
 
-cairo_surface_t *create_pdf_surface(GtkWidget *widget)
+cairo_surface_t *create_and_generate_pdf(GtkWidget *widget, const char *file_name)
 {
-    std::string file_name = "pdf_output";
   int const width = gtk_widget_get_allocated_width(widget);
   int const height = gtk_widget_get_allocated_height(widget);
 
-  return cairo_pdf_surface_create(file_name.c_str(), width, height);
-
+  return cairo_pdf_surface_create(file_name, width, height);
 }
 
-cairo_surface_t *create_svg_surface(GtkWidget *widget)
+cairo_surface_t *create_and_generate_svg(GtkWidget *widget, const char *file_name)
 {
-    std::string file_name = "svg_output";
   int const width = gtk_widget_get_allocated_width(widget);
   int const height = gtk_widget_get_allocated_height(widget);
 
-  return cairo_svg_surface_create(file_name.c_str(), width, height);
-
+  return cairo_svg_surface_create(file_name, width, height);
 }
 
-cairo_surface_t *create_png_surface(GtkWidget *widget)
+cairo_surface_t *create_png(GtkWidget *widget)
 {
   int const width = gtk_widget_get_allocated_width(widget);
   int const height = gtk_widget_get_allocated_height(widget);
 
   return cairo_image_surface_create(CAIRO_FORMAT_ARGB32, width, height);
+}
 
+cairo_public cairo_status_t generate_png(cairo_surface_t *p_surface, const char *file_name)
+{
+  return cairo_surface_write_to_png(p_surface, file_name);
 }
 
 static cairo_t *create_context(cairo_surface_t *p_surface)

--- a/src/canvas.cpp
+++ b/src/canvas.cpp
@@ -25,6 +25,7 @@
 #include <cassert>
 #include <cmath>
 #include <functional>
+#include <iostream>
 
 namespace ezgl {
 
@@ -44,7 +45,7 @@ static cairo_surface_t *create_surface(GtkWidget *widget)
 #endif
 }
 
-static cairo_surface_t *create_pdf_surface(GtkWidget *widget)
+cairo_surface_t *create_pdf_surface(GtkWidget *widget)
 {
     std::string file_name = "pdf_output";
   int const width = gtk_widget_get_allocated_width(widget);
@@ -54,7 +55,7 @@ static cairo_surface_t *create_pdf_surface(GtkWidget *widget)
 
 }
 
-static cairo_surface_t *create_svg_surface(GtkWidget *widget)
+cairo_surface_t *create_svg_surface(GtkWidget *widget)
 {
     std::string file_name = "svg_output";
   int const width = gtk_widget_get_allocated_width(widget);
@@ -64,7 +65,7 @@ static cairo_surface_t *create_svg_surface(GtkWidget *widget)
 
 }
 
-static cairo_surface_t *create_png_surface(GtkWidget *widget)
+cairo_surface_t *create_png_surface(GtkWidget *widget)
 {
   int const width = gtk_widget_get_allocated_width(widget);
   int const height = gtk_widget_get_allocated_height(widget);

--- a/src/canvas.cpp
+++ b/src/canvas.cpp
@@ -29,182 +29,208 @@
 
 namespace ezgl {
 
-static cairo_surface_t *create_surface(GtkWidget *widget)
-{
-  GdkWindow *parent_window = gtk_widget_get_window(widget);
-  int const width = gtk_widget_get_allocated_width(widget);
-  int const height = gtk_widget_get_allocated_height(widget);
+    static cairo_surface_t *create_surface(GtkWidget *widget)
+    {
+      GdkWindow *parent_window = gtk_widget_get_window(widget);
+      int const width = gtk_widget_get_allocated_width(widget);
+      int const height = gtk_widget_get_allocated_height(widget);
 
-  // Cairo image surfaces are more efficient than normal Cairo surfaces
-  // However, you cannot use X11 functions to draw on image surfaces
-#ifdef EZGL_USE_X11
-  return gdk_window_create_similar_surface(parent_window, CAIRO_CONTENT_COLOR_ALPHA, width, height);
-#else
-  return gdk_window_create_similar_image_surface(
-      parent_window, CAIRO_FORMAT_ARGB32, width, height, 0);
-#endif
-}
+      // Cairo image surfaces are more efficient than normal Cairo surfaces
+      // However, you cannot use X11 functions to draw on image surfaces
+    #ifdef EZGL_USE_X11
+      return gdk_window_create_similar_surface(parent_window, CAIRO_CONTENT_COLOR_ALPHA, width, height);
+    #else
+      return gdk_window_create_similar_image_surface(
+          parent_window, CAIRO_FORMAT_ARGB32, width, height, 0);
+    #endif
+    }
 
-cairo_surface_t *create_and_generate_pdf(GtkWidget *widget, const char *file_name)
-{
-  int const width = gtk_widget_get_allocated_width(widget);
-  int const height = gtk_widget_get_allocated_height(widget);
+    cairo_surface_t *create_and_generate_pdf(GtkWidget *widget, const char *file_name)
+    {
+      int const width = gtk_widget_get_allocated_width(widget);
+      int const height = gtk_widget_get_allocated_height(widget);
 
-  return cairo_pdf_surface_create(file_name, width, height);
-}
+      return cairo_pdf_surface_create(file_name, width, height);
+    }
 
-cairo_surface_t *create_and_generate_svg(GtkWidget *widget, const char *file_name)
-{
-  int const width = gtk_widget_get_allocated_width(widget);
-  int const height = gtk_widget_get_allocated_height(widget);
+    cairo_surface_t *create_and_generate_svg(GtkWidget *widget, const char *file_name)
+    {
+      int const width = gtk_widget_get_allocated_width(widget);
+      int const height = gtk_widget_get_allocated_height(widget);
 
-  return cairo_svg_surface_create(file_name, width, height);
-}
+      return cairo_svg_surface_create(file_name, width, height);
+    }
 
-cairo_surface_t *create_png(GtkWidget *widget)
-{
-  int const width = gtk_widget_get_allocated_width(widget);
-  int const height = gtk_widget_get_allocated_height(widget);
+    cairo_surface_t *create_png(GtkWidget *widget)
+    {
+        std::cout << "in here png" <<std::endl;
+      int const width = gtk_widget_get_allocated_width(widget);
+      int const height = gtk_widget_get_allocated_height(widget);
 
-  return cairo_image_surface_create(CAIRO_FORMAT_ARGB32, width, height);
-}
+      return cairo_image_surface_create(CAIRO_FORMAT_ARGB32, width, height);
+    }
 
-cairo_public cairo_status_t generate_png(cairo_surface_t *p_surface, const char *file_name)
-{
-  return cairo_surface_write_to_png(p_surface, file_name);
-}
+    cairo_public cairo_status_t generate_png(cairo_surface_t *p_surface, const char *file_name)
+    {
+      return cairo_surface_write_to_png(p_surface, file_name);
+    }
 
-static cairo_t *create_context(cairo_surface_t *p_surface)
-{
-  cairo_t *context = cairo_create(p_surface);
+    static cairo_t *create_context(cairo_surface_t *p_surface)
+    {
+      cairo_t *context = cairo_create(p_surface);
 
-  // Set the antialiasing mode of the rasterizer used for drawing shapes
-  // Set to CAIRO_ANTIALIAS_NONE for maximum speed
-  // See https://www.cairographics.org/manual/cairo-cairo-t.html#cairo-antialias-t
-  cairo_set_antialias(context, CAIRO_ANTIALIAS_NONE);
+      // Set the antialiasing mode of the rasterizer used for drawing shapes
+      // Set to CAIRO_ANTIALIAS_NONE for maximum speed
+      // See https://www.cairographics.org/manual/cairo-cairo-t.html#cairo-antialias-t
+      cairo_set_antialias(context, CAIRO_ANTIALIAS_NONE);
 
-  return context;
-}
+      return context;
+    }
 
-gboolean canvas::configure_event(GtkWidget *widget, GdkEventConfigure *, gpointer data)
-{
-  // User data should have been set during the signal connection.
-  g_return_val_if_fail(data != nullptr, FALSE);
+    void canvas::print_pdf(const char *file_name)
+    {
+        std::cout << "in here" <<std::endl;
+        cairo_surface_t *surface;
+        cairo_t *context;
+        //GObject *main_widget = application.get_object(application.get_main_window_id().c_str());
+        
+        surface = create_and_generate_pdf(m_drawing_area, file_name);
+        context = create_context(surface);
 
-  auto ezgl_canvas = static_cast<canvas *>(data);
-  auto &p_surface = ezgl_canvas->m_surface;
-  auto &p_context = ezgl_canvas->m_context;
+        cairo_set_source_rgb(context, 0, 0, 0);
+        cairo_select_font_face (context, "Sans", CAIRO_FONT_SLANT_NORMAL,
+            CAIRO_FONT_WEIGHT_NORMAL);
+        cairo_set_font_size (context, 40.0);
 
-  if(p_surface != nullptr) {
-    cairo_surface_destroy(p_surface);
-  }
+        cairo_move_to(context, 10.0, 50.0);
+        cairo_show_text(context, "Disziplin ist Macht.");
 
-  if(p_context != nullptr) {
-    cairo_destroy(p_context);
-  }
+        cairo_show_page(context);
+        
+        //free surface & context
+        cairo_surface_destroy(surface);
+        cairo_destroy(context);
+    }
 
-  // Something has changed, recreate the surface.
-  p_surface = create_surface(widget);
+    gboolean canvas::configure_event(GtkWidget *widget, GdkEventConfigure *, gpointer data)
+    {
+      // User data should have been set during the signal connection.
+      g_return_val_if_fail(data != nullptr, FALSE);
 
-  // Recreate the context
-  p_context = create_context(p_surface);
+      auto ezgl_canvas = static_cast<canvas *>(data);
+      auto &p_surface = ezgl_canvas->m_surface;
+      auto &p_context = ezgl_canvas->m_context;
 
-  // The camera needs to be updated before we start drawing again.
-  ezgl_canvas->m_camera.update_widget(ezgl_canvas->width(), ezgl_canvas->height());
+      if(p_surface != nullptr) {
+        cairo_surface_destroy(p_surface);
+      }
 
-  // Draw to the newly created surface.
-  ezgl_canvas->redraw();
+      if(p_context != nullptr) {
+        cairo_destroy(p_context);
+      }
 
-  g_info("canvas::configure_event has been handled.");
-  return TRUE; // the configure event was handled
-}
+      // Something has changed, recreate the surface.
+      p_surface = create_surface(widget);
 
-gboolean canvas::draw_surface(GtkWidget *, cairo_t *context, gpointer data)
-{
-  // Assume context and data are non-null.
-  auto &p_surface = static_cast<canvas *>(data)->m_surface;
+      // Recreate the context
+      p_context = create_context(p_surface);
 
-  // Assume surface is non-null.
-  cairo_set_source_surface(context, p_surface, 0, 0);
-  cairo_paint(context);
+      // The camera needs to be updated before we start drawing again.
+      ezgl_canvas->m_camera.update_widget(ezgl_canvas->width(), ezgl_canvas->height());
 
-  return FALSE;
-}
+      // Draw to the newly created surface.
+      ezgl_canvas->redraw();
 
-canvas::canvas(std::string canvas_id, draw_canvas_fn draw_callback, rectangle coordinate_system, color background_color)
-    : m_canvas_id(std::move(canvas_id)), m_draw_callback(draw_callback), m_camera(coordinate_system),
-      m_background_color(background_color)
-{
-}
+      g_info("canvas::configure_event has been handled.");
+      return TRUE; // the configure event was handled
+    }
 
-canvas::~canvas()
-{
-  if(m_surface != nullptr) {
-    cairo_surface_destroy(m_surface);
-  }
+    gboolean canvas::draw_surface(GtkWidget *, cairo_t *context, gpointer data)
+    {
+      // Assume context and data are non-null.
+      auto &p_surface = static_cast<canvas *>(data)->m_surface;
 
-  if(m_context != nullptr) {
-    cairo_destroy(m_context);
-  }
-}
+      // Assume surface is non-null.
+      cairo_set_source_surface(context, p_surface, 0, 0);
+      cairo_paint(context);
 
-int canvas::width() const
-{
-  return gtk_widget_get_allocated_width(m_drawing_area);
-}
+      return FALSE;
+    }
 
-int canvas::height() const
-{
-  return gtk_widget_get_allocated_height(m_drawing_area);
-}
+    canvas::canvas(std::string canvas_id, draw_canvas_fn draw_callback, rectangle coordinate_system, color background_color)
+        : m_canvas_id(std::move(canvas_id)), m_draw_callback(draw_callback), m_camera(coordinate_system),
+          m_background_color(background_color)
+    {
+    }
 
-void canvas::initialize(GtkWidget *drawing_area)
-{
-  g_return_if_fail(drawing_area != nullptr);
+    canvas::~canvas()
+    {
+      if(m_surface != nullptr) {
+        cairo_surface_destroy(m_surface);
+      }
 
-  m_drawing_area = drawing_area;
-  m_surface = create_surface(m_drawing_area);
-  m_context = create_context(m_surface);
-  m_camera.update_widget(width(), height());
+      if(m_context != nullptr) {
+        cairo_destroy(m_context);
+      }
+    }
 
-  // Draw to the newly created surface for the first time.
-  redraw();
+    int canvas::width() const
+    {
+      return gtk_widget_get_allocated_width(m_drawing_area);
+    }
 
-  // Connect to configure events in case our widget changes shape.
-  g_signal_connect(m_drawing_area, "configure-event", G_CALLBACK(configure_event), this);
-  // Connect to draw events so that we draw our surface to the drawing area.
-  g_signal_connect(m_drawing_area, "draw", G_CALLBACK(draw_surface), this);
+    int canvas::height() const
+    {
+      return gtk_widget_get_allocated_height(m_drawing_area);
+    }
 
-  // GtkDrawingArea objects need specific events enabled explicitly.
-  gtk_widget_add_events(GTK_WIDGET(m_drawing_area), GDK_BUTTON_PRESS_MASK);
-  gtk_widget_add_events(GTK_WIDGET(m_drawing_area), GDK_BUTTON_RELEASE_MASK);
-  gtk_widget_add_events(GTK_WIDGET(m_drawing_area), GDK_POINTER_MOTION_MASK);
-  gtk_widget_add_events(GTK_WIDGET(m_drawing_area), GDK_SCROLL_MASK);
+    void canvas::initialize(GtkWidget *drawing_area)
+    {
+      g_return_if_fail(drawing_area != nullptr);
 
-  g_info("canvas::initialize successful.");
-}
+      m_drawing_area = drawing_area;
+      m_surface = create_surface(m_drawing_area);
+      m_context = create_context(m_surface);
+      m_camera.update_widget(width(), height());
 
-void canvas::redraw()
-{
-  // Clear the screen and set the background color
-  cairo_set_source_rgb(m_context, m_background_color.red / 255.0,
-		       m_background_color.green / 255.0, m_background_color.blue / 255.0);
-  cairo_paint(m_context);
+      // Draw to the newly created surface for the first time.
+      redraw();
 
-  using namespace std::placeholders;
-  renderer g(m_context, std::bind(&camera::world_to_screen, m_camera, _1), &m_camera, m_surface);
-  m_draw_callback(g);
+      // Connect to configure events in case our widget changes shape.
+      g_signal_connect(m_drawing_area, "configure-event", G_CALLBACK(configure_event), this);
+      // Connect to draw events so that we draw our surface to the drawing area.
+      g_signal_connect(m_drawing_area, "draw", G_CALLBACK(draw_surface), this);
 
-  gtk_widget_queue_draw(m_drawing_area);
+      // GtkDrawingArea objects need specific events enabled explicitly.
+      gtk_widget_add_events(GTK_WIDGET(m_drawing_area), GDK_BUTTON_PRESS_MASK);
+      gtk_widget_add_events(GTK_WIDGET(m_drawing_area), GDK_BUTTON_RELEASE_MASK);
+      gtk_widget_add_events(GTK_WIDGET(m_drawing_area), GDK_POINTER_MOTION_MASK);
+      gtk_widget_add_events(GTK_WIDGET(m_drawing_area), GDK_SCROLL_MASK);
 
-  g_info("The canvas will be redrawn.");
-}
+      g_info("canvas::initialize successful.");
+    }
 
-renderer canvas::create_temporary_renderer()
-{
-  using namespace std::placeholders;
-  renderer g(m_context, std::bind(&camera::world_to_screen, m_camera, _1), &m_camera, m_surface);
+    void canvas::redraw()
+    {
+      // Clear the screen and set the background color
+      cairo_set_source_rgb(m_context, m_background_color.red / 255.0,
+                           m_background_color.green / 255.0, m_background_color.blue / 255.0);
+      cairo_paint(m_context);
 
-  return g;
-}
+      using namespace std::placeholders;
+      renderer g(m_context, std::bind(&camera::world_to_screen, m_camera, _1), &m_camera, m_surface);
+      m_draw_callback(g);
+
+      gtk_widget_queue_draw(m_drawing_area);
+
+      g_info("The canvas will be redrawn.");
+    }
+
+    renderer canvas::create_temporary_renderer()
+    {
+      using namespace std::placeholders;
+      renderer g(m_context, std::bind(&camera::world_to_screen, m_camera, _1), &m_camera, m_surface);
+
+      return g;
+    }
 }


### PR DESCRIPTION
- include cairo-pdf.h and cairo-svg.h
- add create_svg_surface, create_pdf_surface and create_png_surface under ezgl
- tested in basic_application.cpp, code reference [http://zetcode.com/gfx/cairo/cairobackends/](url)