### PR TITLE
Bump CMake version to 3.9

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,4 @@
-# require at least CMake version 3.0.2
-cmake_minimum_required(VERSION 3.0.2 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.9 FATAL_ERROR)
 
 # create the project
 project(


### PR DESCRIPTION
VTR Builds with IPO (inter-procedural optimization) by default, which requires CMake 3.9 to be supported easily. At the moment this causes cmake build warnings like the following when building VTR:
```
CMake Warning (dev) at libs/EXTERNAL/libezgl/CMakeLists.txt:28 (add_library):
  Policy CMP0069 is not set: INTERPROCEDURAL_OPTIMIZATION is enforced when
  enabled.  Run "cmake --help-policy CMP0069" for policy details.  Use the
  cmake_policy command to set the policy and suppress this warning.

  INTERPROCEDURAL_OPTIMIZATION property will be ignored for target 'ezgl'.
This warning is for project developers.  Use -Wno-dev to suppress it.

CMake Warning (dev) at libs/EXTERNAL/libezgl/examples/basic-application/CMakeLists.txt:46 (add_executable):
  Policy CMP0069 is not set: INTERPROCEDURAL_OPTIMIZATION is enforced when
  enabled.  Run "cmake --help-policy CMP0069" for policy details.  Use the
  cmake_policy command to set the policy and suppress this warning.

  INTERPROCEDURAL_OPTIMIZATION property will be ignored for target
  'basic-application'.
This warning is for project developers.  Use -Wno-dev to suppress it.
```

This PR bumps the cmake version required for ezgl to 3.9.

I believe this should have no impact on ECE297, since the UG machines don't use the CMake build path.