### PR TITLE
Treat GTK/X11 includes as system includes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,6 +47,13 @@ add_library(
 target_include_directories(
   ${PROJECT_NAME}
   PUBLIC include
+)
+
+#Treat GTK/X11 headers as system headers so they
+#do not generate compilation warnings
+target_include_directories(
+  ${PROJECT_NAME}
+  SYSTEM
   PUBLIC ${GTK3_INCLUDE_DIRS}
   PUBLIC ${X11_INCLUDE_DIRS}
 )


### PR DESCRIPTION
Currently the GTK/X11 includes are treated as regular non-system includes.
This means they will generate compilation warnings (which end users like VTR are unable to fix/suppress).

By treating them as system headers most compilers will suppress any warnings from them.