### PR TITLE
Do not build examples by default if EZGL is non-root cmake project

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,9 @@ endif()
 # a set of macros has been developed by Makman2 on GitHub to help with this
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/gcr-cmake/macros)
 
+#Is ezgl the root cmake project?
+set(IS_ROOT_PROJECT (${CMAKE_SOURCE_DIR} STREQUAL ${CMAKE_CURRENT_SOURCE_DIR}))
+
 # include the configuration/compile time options for this library
 include(options.cmake)
 

--- a/options.cmake
+++ b/options.cmake
@@ -1,7 +1,7 @@
 option(
   EZGL_BUILD_EXAMPLES
   "Build the EZGL example executables."
-  ON
+  ${IS_ROOT_PROJECT} #Only build examples by default if EZGL is the root cmake project
 )
 
 option(


### PR DESCRIPTION
If EZGL is included within another cmake-based project (e.g. VTR) do not build the examples by default (must be asked for explicitly).