### PR TITLE
Fix non-root project variable condition

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,10 @@ endif()
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/gcr-cmake/macros)
 
 #Is ezgl the root cmake project?
-set(IS_ROOT_PROJECT (${CMAKE_SOURCE_DIR} STREQUAL ${CMAKE_CURRENT_SOURCE_DIR}))
+set(IS_ROOT_PROJECT TRUE)
+if (${CMAKE_SOURCE_DIR} STREQUAL ${CMAKE_CURRENT_SOURCE_DIR})
+    set(IS_ROOT_PROJECT FALSE)
+endif()
 
 # include the configuration/compile time options for this library
 include(options.cmake)


### PR DESCRIPTION
CMake only evaluates operations like STREQUAL in if() or while()
statements, so the previous approach of evaluating it in set() does not
work correctly.