### PR TITLE
Add link to codedocs documentation

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1,5 +1,7 @@
 = EZGL - An Easy Graphics Library
 
+image:https://codedocs.xyz/mariobadr/ezgl.svg[link="https://codedocs.xyz/mariobadr/ezgl"]
+
 EZGL is a library for use in ece297 as a simple way to create a GUI application.
 The library provides a thin wrapper around GTK and drawing functionality.
 


### PR DESCRIPTION
There is a website called codedocs (https://codedocs.xyz) that automatically generates documentation using Doxygen and hosts it on their website. I have enabled it for the EZGL repository (see: https://codedocs.xyz/mariobadr/ezgl/). This pull request adds a little image with a link to the documentation on codedocs.

If we don't want this feature, let me know and I can disable the codedocs website for EZGL and delete this branch.